### PR TITLE
fix milestone for phosphore

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ async function getJiraTicket(ticket, jira_token) {
 async function getMileStoneFromEtiquette(etiquettesTicketJira) {
   if (etiquettesTicketJira.includes("PHOSPHORE")) {
     core.info("on set PHOSPHORE");
-    return 2;
+    return 56;
   }
   if (etiquettesTicketJira.includes("FLUOR-BIS")) {
     core.info("on set FLUOR-BIS");


### PR DESCRIPTION
QA :
http://sinappsird-pic-pr-13.dckpic.apps.darva.com/core/auth/login
--------------------------

PR pour mettre à jour la détection du Milestone phosphore 
Il semble qu'auparavant le milestone de phosphore était le 2, mais maintenant il est à 56 ?
Je ne comprends pas pourquoi on a un milestone closed de label  '0.2'. (closed en octobre visiblement ) , mais c'est celui là que github interceptait quand on envoyait une requête avec le milestone à setter à 2